### PR TITLE
--as-needed relative linking failure fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS=`pkg-config fuse --cflags` -DDEBUG
 LDFLAGS=`pkg-config fuse --libs`
 
 sharebox: sharebox.o git-annex.o slash.o
-	gcc -g -Wall $(LDFLAGS) -o sharebox sharebox.o git-annex.o slash.o
+	gcc -g -Wall -o sharebox sharebox.o git-annex.o slash.o $(LDFLAGS)
 
 sharebox.o: sharebox.c
 	gcc -g -Wall $(CFLAGS) -c sharebox.c


### PR DESCRIPTION
Linked libraries have to be passed after objs to prevent linking failures on some systems.

I had to make that change to achieve to link sharebox on my Ubuntu system.

Below, error I had before making the change:

<pre>
$ make
gcc -g -Wall `pkg-config fuse --libs` -o sharebox sharebox.o git-annex.o slash.o
sharebox.o: In function `sharebox_opt_proc':
/home/julien/repositories/sharebox-fs/sharebox.c:341: undefined reference to `fuse_opt_add_arg'
/home/julien/repositories/sharebox-fs/sharebox.c:342: undefined reference to `fuse_main_real'
/home/julien/repositories/sharebox-fs/sharebox.c:346: undefined reference to `fuse_opt_add_arg'
/home/julien/repositories/sharebox-fs/sharebox.c:347: undefined reference to `fuse_main_real'
sharebox.o: In function `main':
/home/julien/repositories/sharebox-fs/sharebox.c:378: undefined reference to `fuse_opt_parse'
/home/julien/repositories/sharebox-fs/sharebox.c:380: undefined reference to `fuse_main_real'
</pre>


Thanks
